### PR TITLE
Adjusting logic to mark skipped checks and schedule needs jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     name: GPU Suite
     if: >
       (github.event_name == 'push' && github.actor == 'mikaeltw') ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.user.login == 'mikaeltw') ||
-      (github.event_name == 'workflow_dispatch' && github.actor == 'mikaeltw')
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'mikaeltw') ||
+      (github.event_name == 'workflow_dispatch' && github.actor == 'mikaeltw') ||
+      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'chore/changelog-release-'))
     uses: ./.github/workflows/_gpu.yml
     secrets: inherit
     with:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -83,7 +83,6 @@ jobs:
 
   publish-to-testpypi-and-smoke-test:
     name: Publish to TestPyPI And Smoke Test
-    if: "github.event_name != 'pull_request' || !startsWith(github.head_ref, 'chore/changelog-release-')"
     needs: conda-build-test
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- What does this change do and why?
Adjust logic on how GPU Suite and Release Tet to PYPI is scheduled
- Key entry points touched (modules, configs, docs).
GitHub Actions

## Testing
- [x] `make dev` (lint + typecheck + unit/offline tests)
- [x] Additional focused checks (e.g., `make test`, GPU tag, or manual validation):

## Docs & Changelog
- [ ] User-facing change? Add/update docs/examples as needed.
- [ ] If user-facing, add a brief release note below for CHANGELOG/release:

## Labels
- Apply one primary label for Release Drafter: `feature|enhancement`, `bug|fix`, `chore|maintenance|dependencies`, or `test|tests`.
