### PR TITLE
Explicit logic to force coveralls to be scheduled

### DIFF
--- a/.github/workflows/_coveralls.yml
+++ b/.github/workflows/_coveralls.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   _coverage-collection:
     name: _Coverage Collection
+    if: "github.event_name != 'pull_request' || !startsWith(github.head_ref, 'chore/changelog-release-')"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
   coverage-collection:
     name: Coverage Collection
     needs: [unit-and-offline, gpu-suite]
-    if: needs.gpu-suite.result == 'success' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'chore/changelog-release-'))
+    if: >
+      (needs.unit-and-offline.result == 'success' && needs.gpu-suite.result == 'success') ||
+      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'chore/changelog-release-'))
     uses: ./.github/workflows/_coveralls.yml
     with:
       expect: "unit-offline,gpu"
+    secrets: inherit


### PR DESCRIPTION
## Summary
- What does this change do and why?
Get Coveralls to be marked skip for changelog PR
- Key entry points touched (modules, configs, docs).

## Testing
- [x] `make dev` (lint + typecheck + unit/offline tests)
- [x] Additional focused checks (e.g., `make test`, GPU tag, or manual validation):

## Docs & Changelog
- [ ] User-facing change? Add/update docs/examples as needed.
- [ ] If user-facing, add a brief release note below for CHANGELOG/release:

## Labels
- Apply one primary label for Release Drafter: `feature|enhancement`, `bug|fix`, `chore|maintenance|dependencies`, or `test|tests`.
