### PR TITLE
Use always to force scheduling of workflow_call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
     name: Coverage Collection
     needs: [unit-and-offline, gpu-suite]
     if: >
-      (needs.unit-and-offline.result == 'success' && needs.gpu-suite.result == 'success') ||
-      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'chore/changelog-release-'))
+      always() && (
+        (needs.unit-and-offline.result == 'success' && needs.gpu-suite.result == 'success') ||
+        (github.event_name == 'pull_request' && startsWith(github.head_ref, 'chore/changelog-release-'))
+      )
     uses: ./.github/workflows/_coveralls.yml
     with:
       expect: "unit-offline,gpu"


### PR DESCRIPTION
## Summary
- What does this change do and why?
-Use always for handling skipped deps of workflow_calls not scheduling.
- Key entry points touched (modules, configs, docs).

## Testing
- [x] `make dev` (lint + typecheck + unit/offline tests)
- [x] Additional focused checks (e.g., `make test`, GPU tag, or manual validation):

## Docs & Changelog
- [ ] User-facing change? Add/update docs/examples as needed.
- [ ] If user-facing, add a brief release note below for CHANGELOG/release:

## Labels
- Apply one primary label for Release Drafter: `feature|enhancement`, `bug|fix`, `chore|maintenance|dependencies`, or `test|tests`.
