### PR TITLE
Add commitish to release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,7 @@
 
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+commitish: main
 categories:
   - title: 🚀 Features
     labels: [feature, enhancement]


### PR DESCRIPTION
## Summary
- What does this change do and why?
  Releases to be made based on main and not the PR merge itself.
- Key entry points touched (modules, configs, docs).

## Testing
- [x] `make dev` (lint + typecheck + unit/offline tests)
- [x] Additional focused checks (e.g., `make test`, GPU tag, or manual validation):

## Docs & Changelog
- [ ] User-facing change? Add/update docs/examples as needed.
- [ ] If user-facing, add a brief release note below for CHANGELOG/release:

## Labels
- Apply one primary label for Release Drafter: `feature|enhancement`, `bug|fix`, `chore|maintenance|dependencies`, or `test|tests`.
