### PR TITLE
add fromJSON to treat as boolean

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -22,30 +22,30 @@ jobs:
 
     steps:
       - name: Skip build for changelog PR
-        if: ${{ env.IS_CHANGELOG_PR }}
+        if: ${{ fromJSON(env.IS_CHANGELOG_PR) }}
         run: echo "Changelog-only PR - skipping package build."
 
       - name: Checkout
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # For tags
 
       - name: Set up Python
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
 
       - name: Install build tooling
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install build twine
 
       - name: Determine version from git
         id: version
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         run: |
 
           BASE_VERSION=$(git describe --tags --abbrev=0)
@@ -66,11 +66,11 @@ jobs:
           fi
 
       - name: Set SETUPTOOLS_SCM_PRETEND_VERSION for dev builds
-        if: ${{ !env.IS_CHANGELOG_PR && steps.version.outputs.pretend_version != '' }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) && steps.version.outputs.pretend_version != '' }}
         run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.version.outputs.pretend_version }}" >> $GITHUB_ENV
 
       - name: Show effective version
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         run: |
           if [ -n "${SETUPTOOLS_SCM_PRETEND_VERSION:-}" ]; then
             echo "Building version: $SETUPTOOLS_SCM_PRETEND_VERSION"
@@ -79,16 +79,16 @@ jobs:
           fi
 
       - name: Build distributions
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         run: python -m build
 
       - name: Check metadata
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         run: |
           python -m twine check dist/*
 
       - name: Upload dist artifacts
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -27,22 +27,22 @@ jobs:
 
     steps:
       - name: Skip conda build for changelog PR
-        if: ${{ env.IS_CHANGELOG_PR }}
+        if: ${{ fromJSON(env.IS_CHANGELOG_PR) }}
         run: echo "Changelog-only PR - skipping conda build."
 
       - name: Checkout
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: actions/checkout@v4
 
       - name: Download built distributions
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
 
       - name: Set up micromamba
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-name: conda-build-env
@@ -53,7 +53,7 @@ jobs:
 
       - name: Determine PKG_VERSION from sdist
         id: version
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         shell: bash -l {0}
         run: |
           python - <<'PY'
@@ -77,7 +77,7 @@ jobs:
           PY
 
       - name: Build and test conda package
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         shell: bash -l {0}
         env:
           PKG_VERSION: ${{ steps.version.outputs.PKG_VERSION }}
@@ -104,37 +104,37 @@ jobs:
 
     steps:
       - name: No-op deploy for changelog PR
-        if: ${{ env.IS_CHANGELOG_PR }}
+        if: ${{ fromJSON(env.IS_CHANGELOG_PR) }}
         run: echo "Changelog-only PR - skipping TestPyPI upload and smoke tests, but marking deployment as successful."
 
       - name: Download built distributions
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
 
       - name: Upload package to TestPyPI
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Set up Python for smoke test
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Upgrade pip
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         run: |
           python -m pip install --upgrade pip
 
         # Retries are needed since the upload to Test PyPI might not have been indexed yet after
         # the upload in the previous step.
       - name: Install rag-bencher for testing
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10
@@ -145,7 +145,7 @@ jobs:
           command: python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple rag-bencher
 
       - name: Smoke test CLI entrypoints (pip env)
-        if: ${{ !env.IS_CHANGELOG_PR }}
+        if: ${{ !fromJSON(env.IS_CHANGELOG_PR) }}
         run: |
           python -c "import rag_bencher; print('rag_bencher OK')"
           python -m rag_bencher.cli --help


### PR DESCRIPTION
## Summary
- What does this change do and why?
Github actions storrs booleans as strings leading to the string false being true.
Convert to JSON to treat as boolean.
- Key entry points touched (modules, configs, docs).

## Testing
- [x] `make dev` (lint + typecheck + unit/offline tests)
- [x] Additional focused checks (e.g., `make test`, GPU tag, or manual validation):

## Docs & Changelog
- [ ] User-facing change? Add/update docs/examples as needed.
- [ ] If user-facing, add a brief release note below for CHANGELOG/release:

## Labels
- Apply one primary label for Release Drafter: `feature|enhancement`, `bug|fix`, `chore|maintenance|dependencies`, or `test|tests`.
