### PR TITLE
Add base branch option for changelog PR creation

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -160,6 +160,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.CHANGELOG_PAT }}
+          base: ${{ github.event.release.target_commitish || 'main' }}
           branch: chore/changelog-release-${{ steps.release.outputs.tag }}
           title: "chore: update changelog for ${{ steps.release.outputs.tag }}"
           body: "Update CHANGELOG.md with notes from ${{ steps.release.outputs.tag }}."


### PR DESCRIPTION
## Summary
- What does this change do and why?
  After a release, the commit corresponding to the tag is checked out. The PR cannot then infer the branch to open towards. This solves that.
- Key entry points touched (modules, configs, docs).

## Testing
- [x] `make dev` (lint + typecheck + unit/offline tests)
- [x] Additional focused checks (e.g., `make test`, GPU tag, or manual validation):

## Docs & Changelog
- [ ] User-facing change? Add/update docs/examples as needed.
- [ ] If user-facing, add a brief release note below for CHANGELOG/release:

## Labels
- Apply one primary label for Release Drafter: `feature|enhancement`, `bug|fix`, `chore|maintenance|dependencies`, or `test|tests`.
